### PR TITLE
Add fetching perfume detail logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,7 +104,7 @@ dependencies {
 
     // ReadMoreTextView
     implementation("kr.co.prnd:readmore-textview:1.0.0")
-
+    
     // Paging3
     implementation(Libs.AndroidX.Paging.runtime)
     testImplementation(Libs.AndroidX.Paging.common)

--- a/app/src/main/java/com/mashup/lastgarden/data/paging/PerfumeDetailPagingSource.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/paging/PerfumeDetailPagingSource.kt
@@ -33,7 +33,7 @@ class PerfumeDetailPagingSource(
             Log.e(TAG, "HTTPException occured", e)
             return LoadResult.Error(e)
         } catch (e: Exception) {
-            Log.e(this::class.java.simpleName, "Failed to load stories", e)
+            Log.e(TAG, "Failed to load stories", e)
             LoadResult.Error(e)
         }
     }

--- a/app/src/main/java/com/mashup/lastgarden/data/paging/PerfumeDetailPagingSource.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/paging/PerfumeDetailPagingSource.kt
@@ -1,0 +1,47 @@
+package com.mashup.lastgarden.data.paging
+
+import android.util.Log
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.mashup.lastgarden.data.remote.PerfumeDetailRemoteDataSource
+import com.mashup.lastgarden.data.vo.Story
+import retrofit2.HttpException
+import java.io.IOException
+
+class PerfumeDetailPagingSource(
+    private val id: Int,
+    private val remote: PerfumeDetailRemoteDataSource
+) : PagingSource<Int, Story>() {
+    companion object {
+        private const val TAG = "PerfumeDetailPagingSource"
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Story> {
+        return try {
+            val cursor = params.key
+            val response = remote.getStoryByPerfume(id, cursor)
+            val lastPerfume = response.lastOrNull()
+            LoadResult.Page(
+                data = response,
+                prevKey = null,
+                nextKey = lastPerfume?.likeCount?.toInt()
+            )
+        } catch (e: IOException) {
+            Log.e(TAG, "IOException occured", e)
+            return LoadResult.Error(e)
+        } catch (e: HttpException) {
+            Log.e(TAG, "HTTPException occured", e)
+            return LoadResult.Error(e)
+        } catch (e: Exception) {
+            Log.e(this::class.java.simpleName, "Failed to load stories", e)
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Story>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey ?: anchorPage?.nextKey
+        }
+    }
+}

--- a/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
@@ -3,6 +3,7 @@ package com.mashup.lastgarden.data.remote
 import com.mashup.lastgarden.data.vo.Perfume
 import com.mashup.lastgarden.data.vo.PerfumeLike
 import com.mashup.lastgarden.data.vo.Story
+import com.mashup.lastgarden.network.response.onErrorReturnData
 import com.mashup.lastgarden.network.response.onErrorReturnDataNull
 import com.mashup.lastgarden.network.services.PerfumeDetailService
 import javax.inject.Inject
@@ -18,7 +19,7 @@ class PerfumeDetailRemoteDataSource @Inject constructor(private val service: Per
         id: Int,
         cursor: Int? = null
     ): List<Story> = service.getStoryByPerfume(id, cursor)
-        .onErrorReturnDataNull() ?: emptyList()
+        .onErrorReturnData(emptyList())
 
     suspend fun likePerfume(token: String, id: Int): PerfumeLike? =
         service.likePerfume(token, id).onErrorReturnDataNull()

--- a/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
@@ -12,8 +12,8 @@ import javax.inject.Singleton
 @Singleton
 class PerfumeDetailRemoteDataSource @Inject constructor(private val service: PerfumeDetailService) {
 
-    suspend fun fetchPerfumeDetail(token: String, id: Int): Perfume? =
-        service.getPerfumeDetail(token, id).onErrorReturnDataNull()
+    suspend fun fetchPerfumeDetail(id: Int): Perfume? =
+        service.getPerfumeDetail(id).onErrorReturnDataNull()
 
     suspend fun getStoryByPerfume(
         id: Int,
@@ -21,6 +21,6 @@ class PerfumeDetailRemoteDataSource @Inject constructor(private val service: Per
     ): List<Story> = service.getStoryByPerfume(id, cursor)
         .onErrorReturnData(emptyList())
 
-    suspend fun likePerfume(token: String, id: Int): PerfumeLike? =
-        service.likePerfume(token, id).onErrorReturnDataNull()
+    suspend fun likePerfume(id: Int): PerfumeLike? =
+        service.likePerfume(id).onErrorReturnDataNull()
 }

--- a/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
@@ -1,0 +1,21 @@
+package com.mashup.lastgarden.data.remote
+
+import com.mashup.lastgarden.data.vo.Perfume
+import com.mashup.lastgarden.data.vo.Story
+import com.mashup.lastgarden.network.response.onErrorReturnDataNull
+import com.mashup.lastgarden.network.services.PerfumeDetailService
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PerfumeDetailRemoteDataSource @Inject constructor(private val service: PerfumeDetailService) {
+
+    suspend fun fetchPerfumeDetail(id: Int): Perfume? =
+        service.getPerfumeDetail(id).onErrorReturnDataNull()
+
+    suspend fun getStoryByPerfume(
+        id: Int,
+        cursor: Int? = null
+    ): List<Story> = service.getStoryByPerfume(id, cursor)
+        .onErrorReturnDataNull() ?: emptyList()
+}

--- a/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/remote/PerfumeDetailRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.mashup.lastgarden.data.remote
 
 import com.mashup.lastgarden.data.vo.Perfume
+import com.mashup.lastgarden.data.vo.PerfumeLike
 import com.mashup.lastgarden.data.vo.Story
 import com.mashup.lastgarden.network.response.onErrorReturnDataNull
 import com.mashup.lastgarden.network.services.PerfumeDetailService
@@ -10,12 +11,15 @@ import javax.inject.Singleton
 @Singleton
 class PerfumeDetailRemoteDataSource @Inject constructor(private val service: PerfumeDetailService) {
 
-    suspend fun fetchPerfumeDetail(id: Int): Perfume? =
-        service.getPerfumeDetail(id).onErrorReturnDataNull()
+    suspend fun fetchPerfumeDetail(token: String, id: Int): Perfume? =
+        service.getPerfumeDetail(token, id).onErrorReturnDataNull()
 
     suspend fun getStoryByPerfume(
         id: Int,
         cursor: Int? = null
     ): List<Story> = service.getStoryByPerfume(id, cursor)
         .onErrorReturnDataNull() ?: emptyList()
+
+    suspend fun likePerfume(token: String, id: Int): PerfumeLike? =
+        service.likePerfume(token, id).onErrorReturnDataNull()
 }

--- a/app/src/main/java/com/mashup/lastgarden/data/repository/PerfumeDetailRepository.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/repository/PerfumeDetailRepository.kt
@@ -1,0 +1,23 @@
+package com.mashup.lastgarden.data.repository
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.mashup.lastgarden.data.paging.PerfumeDetailPagingSource
+import com.mashup.lastgarden.data.remote.PerfumeDetailRemoteDataSource
+import com.mashup.lastgarden.data.vo.Perfume
+import com.mashup.lastgarden.data.vo.Story
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PerfumeDetailRepository @Inject constructor(private val remote: PerfumeDetailRemoteDataSource) {
+
+    suspend fun fetchPerfumeDetail(id: Int): Perfume? = remote.fetchPerfumeDetail(id)
+
+    fun getStoryByPerfume(id: Int, pageSize: Int): Flow<PagingData<Story>> =
+        Pager(PagingConfig(pageSize)) {
+            PerfumeDetailPagingSource(id, remote)
+        }.flow
+}

--- a/app/src/main/java/com/mashup/lastgarden/data/repository/PerfumeDetailRepository.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/repository/PerfumeDetailRepository.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingData
 import com.mashup.lastgarden.data.paging.PerfumeDetailPagingSource
 import com.mashup.lastgarden.data.remote.PerfumeDetailRemoteDataSource
 import com.mashup.lastgarden.data.vo.Perfume
+import com.mashup.lastgarden.data.vo.PerfumeLike
 import com.mashup.lastgarden.data.vo.Story
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -14,10 +15,13 @@ import javax.inject.Singleton
 @Singleton
 class PerfumeDetailRepository @Inject constructor(private val remote: PerfumeDetailRemoteDataSource) {
 
-    suspend fun fetchPerfumeDetail(id: Int): Perfume? = remote.fetchPerfumeDetail(id)
+    suspend fun fetchPerfumeDetail(token: String, id: Int): Perfume? =
+        remote.fetchPerfumeDetail(token, id)
 
     fun getStoryByPerfume(id: Int, pageSize: Int): Flow<PagingData<Story>> =
         Pager(PagingConfig(pageSize)) {
             PerfumeDetailPagingSource(id, remote)
         }.flow
+
+    suspend fun likePerfume(token: String, id: Int): PerfumeLike? = remote.likePerfume(token, id)
 }

--- a/app/src/main/java/com/mashup/lastgarden/data/repository/PerfumeDetailRepository.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/repository/PerfumeDetailRepository.kt
@@ -15,13 +15,13 @@ import javax.inject.Singleton
 @Singleton
 class PerfumeDetailRepository @Inject constructor(private val remote: PerfumeDetailRemoteDataSource) {
 
-    suspend fun fetchPerfumeDetail(token: String, id: Int): Perfume? =
-        remote.fetchPerfumeDetail(token, id)
+    suspend fun fetchPerfumeDetail(id: Int): Perfume? =
+        remote.fetchPerfumeDetail(id)
 
     fun getStoryByPerfume(id: Int, pageSize: Int): Flow<PagingData<Story>> =
         Pager(PagingConfig(pageSize)) {
             PerfumeDetailPagingSource(id, remote)
         }.flow
 
-    suspend fun likePerfume(token: String, id: Int): PerfumeLike? = remote.likePerfume(token, id)
+    suspend fun likePerfume(id: Int): PerfumeLike? = remote.likePerfume(id)
 }

--- a/app/src/main/java/com/mashup/lastgarden/data/vo/Perfume.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/vo/Perfume.kt
@@ -18,7 +18,8 @@ data class Perfume(
     @ColumnInfo(name = "perfume_second_name") @SerializedName("perfume_name") val perfumeName: String? = null,
     @ColumnInfo(name = "perfume_is_liked") val isLiked: Boolean = false,
     @Ignore val notes: NoteContainer? = null,
-    @Ignore val rank: Int? = null
+    @Ignore val rank: Int? = null,
+    @Ignore val accords: List<Note>? = null
 ) {
     constructor(
         perfumeId: Int,
@@ -41,7 +42,8 @@ data class Perfume(
         perfumeName = perfumeName,
         isLiked = isLiked,
         notes = null,
-        rank = null
+        rank = null,
+        accords = null
     )
 
     data class NoteContainer(

--- a/app/src/main/java/com/mashup/lastgarden/data/vo/PerfumeLike.kt
+++ b/app/src/main/java/com/mashup/lastgarden/data/vo/PerfumeLike.kt
@@ -1,0 +1,5 @@
+package com.mashup.lastgarden.data.vo
+
+data class PerfumeLike(
+    val isLiked: Boolean
+)

--- a/app/src/main/java/com/mashup/lastgarden/di/ServiceModule.kt
+++ b/app/src/main/java/com/mashup/lastgarden/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.mashup.lastgarden.di
 
 import com.mashup.base.network.PerfumeRetrofit
+import com.mashup.lastgarden.network.services.PerfumeDetailService
 import com.mashup.lastgarden.network.services.PerfumeService
 import com.mashup.lastgarden.network.services.StoryService
 import com.mashup.lastgarden.network.services.UserService
@@ -24,5 +25,9 @@ object ServiceModule {
 
     @Provides
     fun provideStoryService(okHttpClient: OkHttpClient): StoryService =
+        PerfumeRetrofit.create(okHttpClient)
+
+    @Provides
+    fun providePerfumeDetailService(okHttpClient: OkHttpClient): PerfumeDetailService =
         PerfumeRetrofit.create(okHttpClient)
 }

--- a/app/src/main/java/com/mashup/lastgarden/network/services/PerfumeDetailService.kt
+++ b/app/src/main/java/com/mashup/lastgarden/network/services/PerfumeDetailService.kt
@@ -5,7 +5,6 @@ import com.mashup.lastgarden.data.vo.PerfumeLike
 import com.mashup.lastgarden.data.vo.Story
 import com.mashup.lastgarden.network.response.NetworkDataResponse
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -14,7 +13,6 @@ interface PerfumeDetailService {
 
     @GET("perfume/{id}")
     suspend fun getPerfumeDetail(
-        @Header("Authorization") token: String,
         @Path("id") id: Int
     ): NetworkDataResponse<Perfume>
 
@@ -26,7 +24,6 @@ interface PerfumeDetailService {
 
     @POST("perfume/{id}/like")
     suspend fun likePerfume(
-        @Header("Authorization") token: String,
         @Path("id") id: Int
     ): NetworkDataResponse<PerfumeLike>
 }

--- a/app/src/main/java/com/mashup/lastgarden/network/services/PerfumeDetailService.kt
+++ b/app/src/main/java/com/mashup/lastgarden/network/services/PerfumeDetailService.kt
@@ -1,9 +1,12 @@
 package com.mashup.lastgarden.network.services
 
 import com.mashup.lastgarden.data.vo.Perfume
+import com.mashup.lastgarden.data.vo.PerfumeLike
 import com.mashup.lastgarden.data.vo.Story
 import com.mashup.lastgarden.network.response.NetworkDataResponse
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -11,6 +14,7 @@ interface PerfumeDetailService {
 
     @GET("perfume/{id}")
     suspend fun getPerfumeDetail(
+        @Header("Authorization") token: String,
         @Path("id") id: Int
     ): NetworkDataResponse<Perfume>
 
@@ -19,4 +23,10 @@ interface PerfumeDetailService {
         @Path("id") id: Int,
         @Query("cursor") cursor: Int? = null
     ): NetworkDataResponse<List<Story>>
+
+    @POST("perfume/{id}/like")
+    suspend fun likePerfume(
+        @Header("Authorization") token: String,
+        @Path("id") id: Int
+    ): NetworkDataResponse<PerfumeLike>
 }

--- a/app/src/main/java/com/mashup/lastgarden/network/services/PerfumeDetailService.kt
+++ b/app/src/main/java/com/mashup/lastgarden/network/services/PerfumeDetailService.kt
@@ -1,0 +1,22 @@
+package com.mashup.lastgarden.network.services
+
+import com.mashup.lastgarden.data.vo.Perfume
+import com.mashup.lastgarden.data.vo.Story
+import com.mashup.lastgarden.network.response.NetworkDataResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface PerfumeDetailService {
+
+    @GET("perfume/{id}")
+    suspend fun getPerfumeDetail(
+        @Path("id") id: Int
+    ): NetworkDataResponse<Perfume>
+
+    @GET("perfume/{id}/story")
+    suspend fun getStoryByPerfume(
+        @Path("id") id: Int,
+        @Query("cursor") cursor: Int? = null
+    ): NetworkDataResponse<List<Story>>
+}

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailAdapter.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailAdapter.kt
@@ -18,7 +18,7 @@ class PerfumeDetailAdapter(private val glideRequests: GlideRequests) :
                 override fun areItemsTheSame(
                     oldItem: PerfumeDetailItem,
                     newItem: PerfumeDetailItem
-                ): Boolean = oldItem.storyId == newItem.storyId
+                ): Boolean = oldItem.id == newItem.id
 
                 override fun areContentsTheSame(
                     oldItem: PerfumeDetailItem,
@@ -48,8 +48,8 @@ class ScentListViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(data: PerfumeDetailItem) {
-        binding.perfumeCardView.setUserImage(glideRequests, data.userProfileImage)
-        binding.perfumeCardView.setSourceImage(glideRequests, data.thumbnailUrl)
+        binding.perfumeCardView.setUserImage(glideRequests, data.userProfileImageUrl)
+        binding.perfumeCardView.setSourceImage(glideRequests, data.imageUrl)
         binding.perfumeCardView.userName = data.userNickname
         binding.perfumeCardView.count = data.likeCount
         if (data.tags != null)

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
@@ -51,6 +51,7 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
         initToolbar()
         initViewPager()
         initTabLayout()
+        addListenerOnLikeButton()
     }
 
     override fun onBindViewModelsOnCreate() {
@@ -66,6 +67,17 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
                 .filterNotNull()
                 .collectLatest {
                     binding.likeCountTextView.text = it.toString()
+                }
+        }
+        lifecycleScope.launchWhenCreated {
+            viewModel.isLiked
+                .filterNotNull()
+                .collectLatest { isLiked ->
+                    if (isLiked) {
+                        binding.likeImageView.setImageResource(R.drawable.ic_like)
+                    } else {
+                        binding.likeImageView.setImageResource(R.drawable.ic_like_empty)
+                    }
                 }
         }
     }
@@ -124,6 +136,12 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
                     imageUrl = it
                 )
             }
+        }
+    }
+
+    private fun addListenerOnLikeButton() {
+        binding.likeButton.setOnClickListener {
+            viewModel.likePerfume()
         }
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ScrollView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.viewModels
@@ -14,6 +15,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.mashup.base.autoCleared
 import com.mashup.base.extensions.loadImage
 import com.mashup.base.image.GlideRequests
+import com.mashup.base.utils.dp
 import com.mashup.lastgarden.R
 import com.mashup.lastgarden.data.vo.Perfume
 import com.mashup.lastgarden.databinding.FragmentPerfumeDetailBinding
@@ -54,7 +56,7 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
         addListenerOnLikeButton()
     }
 
-    override fun onBindViewModelsOnCreate() {
+    override fun onBindViewModelsOnViewCreated() {
         lifecycleScope.launchWhenCreated {
             viewModel.perfumeDetailItem
                 .filterNotNull()
@@ -96,22 +98,34 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
             ScentListFragment()
         )
         binding.viewPager.adapter = viewPagerAdapter
-        binding.viewPager.setPageTransformer { page, _ ->
-            updatePagerHeight(page, binding.viewPager)
-        }
+        binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                updatePagerHeight(position, binding.viewPager)
+            }
+        })
     }
 
-    private fun updatePagerHeight(view: View, viewPager: ViewPager2) {
-        view.post {
-            val weightMeasureSpec =
-                View.MeasureSpec.makeMeasureSpec(view.width, View.MeasureSpec.EXACTLY)
-            val heightMeasureSpec =
-                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-            view.measure(weightMeasureSpec, heightMeasureSpec)
+    private fun updatePagerHeight(position: Int, viewPager: ViewPager2) {
+        if (position == 0) {
+            viewPager.post {
+                val view = viewPager.findViewById<ScrollView>(R.id.perfumeInformationContainer)
+                view.measure(
+                    View.MeasureSpec.makeMeasureSpec(
+                        View.MeasureSpec.UNSPECIFIED,
+                        View.MeasureSpec.UNSPECIFIED
+                    ),
+                    View.MeasureSpec.makeMeasureSpec(
+                        View.MeasureSpec.UNSPECIFIED,
+                        View.MeasureSpec.UNSPECIFIED
+                    )
+                )
 
-            if (viewPager.layoutParams.height != view.measuredHeight) {
-                viewPager.updateLayoutParams {
-                    height = view.measuredHeight
+                if (viewPager.layoutParams.height != view.measuredHeight) {
+                    viewPager.updateLayoutParams {
+                        val maxHeight = resources.displayMetrics.heightPixels - 246.dp
+                        height = view.measuredHeight.coerceAtMost(maxHeight)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
@@ -6,10 +6,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
 import com.mashup.base.autoCleared
@@ -54,7 +56,7 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
         initToolbar()
         initViewPager()
         initTabLayout()
-        addListenerOnLikeButton()
+        addListeners()
     }
 
     override fun onBindViewModelsOnViewCreated() {
@@ -151,9 +153,15 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
         }
     }
 
-    private fun addListenerOnLikeButton() {
+    private fun addListeners() {
         binding.likeButton.setOnSingleClickListener {
             viewModel.likePerfume()
+        }
+        binding.nextButton.setOnClickListener {
+            findNavController().navigate(
+                R.id.actionPerfumeDetailFragmentToScentFragment,
+                bundleOf("perfumeId" to viewModel.perfumeId)
+            )
         }
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailFragment.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ScrollView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.updateLayoutParams
+import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
@@ -20,6 +20,7 @@ import com.mashup.lastgarden.R
 import com.mashup.lastgarden.data.vo.Perfume
 import com.mashup.lastgarden.databinding.FragmentPerfumeDetailBinding
 import com.mashup.lastgarden.ui.BaseViewModelFragment
+import com.mashup.lastgarden.utils.setOnSingleClickListener
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
@@ -62,6 +63,7 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
                 .filterNotNull()
                 .collectLatest {
                     setPerfumeDetail(it)
+                    viewModel.setPerfumeLike()
                 }
         }
         lifecycleScope.launchWhenCreated {
@@ -109,7 +111,8 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
     private fun updatePagerHeight(position: Int, viewPager: ViewPager2) {
         if (position == 0) {
             viewPager.post {
-                val view = viewPager.findViewById<ScrollView>(R.id.perfumeInformationContainer)
+                val view =
+                    viewPager.findViewById<NestedScrollView>(R.id.perfumeInformationContainer)
                 view.measure(
                     View.MeasureSpec.makeMeasureSpec(
                         View.MeasureSpec.UNSPECIFIED,
@@ -144,17 +147,12 @@ class PerfumeDetailFragment : BaseViewModelFragment() {
         binding.apply {
             titleTextView.text = perfumeItem.koreanName
             titleEngTextView.text = perfumeItem.name
-            perfumeItem.thumbnailUrl?.let {
-                photoImageView.loadImage(
-                    glideRequests = glideRequests,
-                    imageUrl = it
-                )
-            }
+            photoImageView.loadImage(glideRequests, perfumeItem.thumbnailUrl)
         }
     }
 
     private fun addListenerOnLikeButton() {
-        binding.likeButton.setOnClickListener {
+        binding.likeButton.setOnSingleClickListener {
             viewModel.likePerfume()
         }
     }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailItem.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailItem.kt
@@ -1,12 +1,23 @@
 package com.mashup.lastgarden.ui.main
 
+import com.mashup.lastgarden.data.vo.Story
 import com.mashup.lastgarden.data.vo.Tag
 
 data class PerfumeDetailItem(
-    val storyId: Int,
-    val thumbnailUrl: String? = null,
-    val userProfileImage: String? = null,
+    val id: Int,
+    val imageUrl: String? = null,
+    val userProfileImageUrl: String? = null,
     val userNickname: String,
     val likeCount: Long? = 0L,
     val tags: List<Tag>? = emptyList()
 )
+
+fun Story.toPerfumeDetailStoryItem(): PerfumeDetailItem =
+    PerfumeDetailItem(
+        id = storyId,
+        imageUrl = thumbnailUrl,
+        userProfileImageUrl = userProfileImage,
+        userNickname = userNickname,
+        likeCount = likeCount,
+        tags = tags
+    )

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailPagingAdapter.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailPagingAdapter.kt
@@ -1,0 +1,41 @@
+package com.mashup.lastgarden.ui.main
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import com.mashup.base.image.GlideRequests
+import com.mashup.lastgarden.databinding.ItemPerfumeDetailBinding
+
+class PerfumeDetailPagingAdapter(private val glideRequests: GlideRequests) :
+    PagingDataAdapter<PerfumeDetailItem, PerfumeDetailViewHolder>(DIFF_CALLBACK) {
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<PerfumeDetailItem>() {
+            override fun areItemsTheSame(
+                oldItem: PerfumeDetailItem,
+                newItem: PerfumeDetailItem
+            ): Boolean = oldItem.id == newItem.id
+
+            override fun areContentsTheSame(
+                oldItem: PerfumeDetailItem,
+                newItem: PerfumeDetailItem
+            ): Boolean = oldItem == newItem
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PerfumeDetailViewHolder {
+        return PerfumeDetailViewHolder(
+            ItemPerfumeDetailBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: PerfumeDetailViewHolder, position: Int) {
+        val item = getItem(position) ?: return
+        holder.bind(glideRequests, item)
+    }
+}

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailPagingAdapter.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailPagingAdapter.kt
@@ -7,8 +7,10 @@ import androidx.recyclerview.widget.DiffUtil
 import com.mashup.base.image.GlideRequests
 import com.mashup.lastgarden.databinding.ItemPerfumeDetailBinding
 
-class PerfumeDetailPagingAdapter(private val glideRequests: GlideRequests) :
-    PagingDataAdapter<PerfumeDetailItem, PerfumeDetailViewHolder>(DIFF_CALLBACK) {
+class PerfumeDetailPagingAdapter(
+    private val glideRequests: GlideRequests
+) : PagingDataAdapter<PerfumeDetailItem, PerfumeDetailViewHolder>(DIFF_CALLBACK) {
+    private lateinit var storyClickListener: OnItemClickListener
 
     companion object {
         private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<PerfumeDetailItem>() {
@@ -37,5 +39,16 @@ class PerfumeDetailPagingAdapter(private val glideRequests: GlideRequests) :
     override fun onBindViewHolder(holder: PerfumeDetailViewHolder, position: Int) {
         val item = getItem(position) ?: return
         holder.bind(glideRequests, item)
+        holder.itemView.setOnClickListener {
+            storyClickListener.onStoryItemClick(item.id, position)
+        }
+    }
+
+    interface OnItemClickListener {
+        fun onStoryItemClick(storyId: Int, storyIndex: Int)
+    }
+
+    fun setItemClickListener(onItemClickListener: OnItemClickListener) {
+        this.storyClickListener = onItemClickListener
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewHolder.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewHolder.kt
@@ -1,0 +1,22 @@
+package com.mashup.lastgarden.ui.main
+
+import android.text.TextUtils
+import androidx.recyclerview.widget.RecyclerView
+import com.mashup.base.image.GlideRequests
+import com.mashup.lastgarden.databinding.ItemPerfumeDetailBinding
+
+class PerfumeDetailViewHolder(private val binding: ItemPerfumeDetailBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+    fun bind(
+        glideRequests: GlideRequests,
+        item: PerfumeDetailItem
+    ) {
+        binding.perfumeCardView.setUserImage(glideRequests, item.userProfileImageUrl)
+        binding.perfumeCardView.setSourceImage(glideRequests, item.imageUrl)
+        binding.perfumeCardView.userName = item.userNickname
+        binding.perfumeCardView.count = item.likeCount
+        if (item.tags != null)
+            binding.perfumeCardView.title =
+                TextUtils.join(" ", item.tags.map { tag -> "#${tag.contents}" })
+    }
+}

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
@@ -1,81 +1,124 @@
 package com.mashup.lastgarden.ui.main
 
+import android.text.TextUtils
 import androidx.lifecycle.ViewModel
-import com.mashup.lastgarden.data.vo.Tag
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.mashup.lastgarden.data.repository.PerfumeDetailRepository
+import com.mashup.lastgarden.data.vo.Note
+import com.mashup.lastgarden.data.vo.Perfume
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class PerfumeDetailViewModel @Inject constructor() : ViewModel() {
+class PerfumeDetailViewModel @Inject constructor(
+    private val perfumeDetailRepository: PerfumeDetailRepository
+) : ViewModel() {
 
-    private val _perfumeDetailItems = MutableStateFlow<List<PerfumeDetailItem>>(emptyList())
-    val perfumeDetailItems: StateFlow<List<PerfumeDetailItem>> = _perfumeDetailItems
+    companion object {
+        private const val PAGE_SIZE = 10
+    }
+
+    // TODO: Change perfume id value
+    private val perfumeId = 1
+
+    private val _perfumeDetailItem = MutableStateFlow<Perfume?>(null)
+    val perfumeDetailItem: StateFlow<Perfume?> = _perfumeDetailItem
+
+    private val _mainAccords = MutableStateFlow<String?>(null)
+    val mainAccords: StateFlow<String?> = _mainAccords
+
+    private val _selectedNote = MutableStateFlow<PerfumeDetailNote?>(null)
+    val selectedNote: StateFlow<PerfumeDetailNote?> = _selectedNote
+
+    private val _noteContents = MutableStateFlow<String?>(null)
+    val noteContents: StateFlow<String?> = _noteContents
+
+    private val _likeCount = MutableStateFlow<Int?>(null)
+    val likeCount: StateFlow<Int?> = _likeCount
+
+    val storyItems: Flow<PagingData<PerfumeDetailItem>> = perfumeDetailRepository
+        .getStoryByPerfume(perfumeId, PAGE_SIZE)
+        .map { pagingData -> pagingData.map { story -> story.toPerfumeDetailStoryItem() } }
+        .cachedIn(viewModelScope)
 
     init {
-        _perfumeDetailItems.value = listOf(
-            PerfumeDetailItem(
-                storyId = 1,
-                thumbnailUrl = "https://images.unsplash.com/photo-1633178082360-4f2b133c7399?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=687&q=80",
-                userProfileImage = "https://images.unsplash.com/photo-1633098205447-de387b769109?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=765&q=80",
-                userNickname = "seehyang",
-                likeCount = 200,
-                tags = listOf(
-                    Tag(tagId = 10, contents = "플로럴"),
-                    Tag(tagId = 11, contents = "우디"),
-                    Tag(tagId = 12, contents = "머스크")
-                )
-            ), PerfumeDetailItem(
-                storyId = 2,
-                thumbnailUrl = "https://images.unsplash.com/photo-1633090332452-532d6b39422a?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2516&q=80",
-                userProfileImage = "https://images.unsplash.com/photo-1633098205447-de387b769109?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=765&q=80",
-                userNickname = "seehyang",
-                likeCount = 100,
-                tags = listOf(
-                    Tag(tagId = 12, contents = "머스크")
-                )
-            ), PerfumeDetailItem(
-                storyId = 3,
-                thumbnailUrl = "https://images.unsplash.com/photo-1633074320366-365b5e382fb5?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1374&q=80",
-                userProfileImage = "https://images.unsplash.com/photo-1633098205447-de387b769109?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=765&q=80",
-                userNickname = "seehyang",
-                likeCount = 300,
-                tags = listOf(
-                    Tag(tagId = 12, contents = "머스크"),
-                    Tag(tagId = 13, contents = "시트러스")
-                )
-            ), PerfumeDetailItem(
-                storyId = 4,
-                thumbnailUrl = "https://images.unsplash.com/photo-1633124890681-fc9afca4c4ac?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=687&q=80",
-                userProfileImage = "https://images.unsplash.com/photo-1633098205447-de387b769109?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=765&q=80",
-                userNickname = "seehyang",
-                likeCount = 250,
-                tags = listOf(
-                    Tag(tagId = 10, contents = "플로럴"),
-                    Tag(tagId = 11, contents = "우디"),
-                    Tag(tagId = 12, contents = "머스크")
-                )
-            ), PerfumeDetailItem(
-                storyId = 5,
-                thumbnailUrl = "https://images.unsplash.com/photo-1633131902932-31ba72ee19d7?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1470&q=80",
-                userProfileImage = "https://images.unsplash.com/photo-1633098205447-de387b769109?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=765&q=80",
-                userNickname = "seehyang",
-                likeCount = 90,
-                tags = listOf(
-                    Tag(tagId = 12, contents = "머스크")
-                )
-            ), PerfumeDetailItem(
-                storyId = 6,
-                thumbnailUrl = "https://images.unsplash.com/photo-1633166158652-22faaa722751?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=687&q=80",
-                userProfileImage = "https://images.unsplash.com/photo-1633098205447-de387b769109?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=765&q=80",
-                userNickname = "seehyang",
-                likeCount = 50,
-                tags = listOf(
-                    Tag(tagId = 12, contents = "머스크"),
-                    Tag(tagId = 13, contents = "시트러스")
-                )
+        viewModelScope.launch(Dispatchers.IO) {
+            _perfumeDetailItem.value = perfumeDetailRepository.fetchPerfumeDetail(perfumeId)
+            setMainAccords()
+            initSelectedNote()
+            initLikeCount()
+        }
+    }
+
+    private fun setMainAccords() {
+        _perfumeDetailItem.value?.accords?.let { accords ->
+            _mainAccords.value = TextUtils.join(
+                ", ",
+                accords.map { it.koreanName }
             )
+        }
+    }
+
+    private fun initSelectedNote() {
+        if (_perfumeDetailItem.value?.notes?.default.isNullOrEmpty()) {
+            setSelectedNote(PerfumeDetailNote.TOP)
+        } else {
+            setSelectedNote(null)
+        }
+    }
+
+    private fun initLikeCount() {
+        _likeCount.value = _perfumeDetailItem.value?.likeCount?.toInt()
+    }
+
+    fun setSelectedNote(note: PerfumeDetailNote?) {
+        _selectedNote.value = note
+    }
+
+    fun setNoteContents() {
+        when (_selectedNote.value) {
+            PerfumeDetailNote.TOP -> {
+                _perfumeDetailItem.value?.notes?.top?.let { top ->
+                    _noteContents.value = formatNoteContents(top)
+                }
+            }
+            PerfumeDetailNote.MIDDLE -> {
+                _perfumeDetailItem.value?.notes?.middle?.let { middle ->
+                    _noteContents.value = formatNoteContents(middle)
+                }
+            }
+            PerfumeDetailNote.BASE -> {
+                _perfumeDetailItem.value?.notes?.base?.let { base ->
+                    _noteContents.value = formatNoteContents(base)
+                }
+            }
+            else -> {
+                _perfumeDetailItem.value?.notes?.default?.let { default ->
+                    _noteContents.value = formatNoteContents(default)
+                }
+            }
+        }
+    }
+
+    private fun formatNoteContents(note: List<Note>): String {
+        return TextUtils.join(
+            ", ",
+            note.map { it.koreanName }
         )
+    }
+
+    enum class PerfumeDetailNote {
+        TOP,
+        MIDDLE,
+        BASE
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
@@ -33,11 +33,9 @@ class PerfumeDetailViewModel @Inject constructor(
     private val _perfumeDetailItem = MutableStateFlow<Perfume?>(null)
     val perfumeDetailItem: StateFlow<Perfume?> = _perfumeDetailItem
 
-    private val _mainAccords = MutableStateFlow<String?>(null)
-    val mainAccords: StateFlow<String?> = _mainAccords
-
     private val _selectedNote = MutableStateFlow<PerfumeDetailNote?>(null)
     val selectedNote: StateFlow<PerfumeDetailNote?> = _selectedNote
+    val selectedNoteValue: PerfumeDetailNote? get() = _selectedNote.value
 
     private val _noteContents = MutableStateFlow<String?>(null)
     val noteContents: StateFlow<String?> = _noteContents
@@ -54,37 +52,21 @@ class PerfumeDetailViewModel @Inject constructor(
         .cachedIn(viewModelScope)
 
     init {
-        getPerfumeDetail()
+        fetchPerfumeDetail()
     }
 
-    private fun getPerfumeDetail() {
+    private fun fetchPerfumeDetail() {
         viewModelScope.launch(Dispatchers.IO) {
-            fetchPerfumeDetail()
-            setMainAccords()
-            initSelectedNote()
-            setPerfumeLike()
+            // TODO: get access token
+            _perfumeDetailItem.value =
+                perfumeDetailRepository.fetchPerfumeDetail(
+                    token = "",
+                    id = perfumeId
+                )
         }
     }
 
-    private suspend fun fetchPerfumeDetail() {
-        // TODO: get access token
-        _perfumeDetailItem.value =
-            perfumeDetailRepository.fetchPerfumeDetail(
-                token = "",
-                id = perfumeId
-            )
-    }
-
-    private fun setMainAccords() {
-        _perfumeDetailItem.value?.accords?.let { accords ->
-            _mainAccords.value = TextUtils.join(
-                ", ",
-                accords.map { it.koreanName }
-            )
-        }
-    }
-
-    private fun initSelectedNote() {
+    fun initSelectedNote() {
         if (_perfumeDetailItem.value?.notes?.default.isNullOrEmpty()) {
             setSelectedNote(PerfumeDetailNote.TOP)
         } else {
@@ -92,7 +74,7 @@ class PerfumeDetailViewModel @Inject constructor(
         }
     }
 
-    private fun setPerfumeLike() {
+    fun setPerfumeLike() {
         _isLiked.value = _perfumeDetailItem.value?.isLiked
         _likeCount.value = _perfumeDetailItem.value?.likeCount?.toInt()
     }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
@@ -42,6 +42,9 @@ class PerfumeDetailViewModel @Inject constructor(
     private val _noteContents = MutableStateFlow<String?>(null)
     val noteContents: StateFlow<String?> = _noteContents
 
+    private val _isLiked = MutableStateFlow<Boolean?>(null)
+    val isLiked: StateFlow<Boolean?> = _isLiked
+
     private val _likeCount = MutableStateFlow<Int?>(null)
     val likeCount: StateFlow<Int?> = _likeCount
 
@@ -51,12 +54,25 @@ class PerfumeDetailViewModel @Inject constructor(
         .cachedIn(viewModelScope)
 
     init {
+        getPerfumeDetail()
+    }
+
+    private fun getPerfumeDetail() {
         viewModelScope.launch(Dispatchers.IO) {
-            _perfumeDetailItem.value = perfumeDetailRepository.fetchPerfumeDetail(perfumeId)
+            fetchPerfumeDetail()
             setMainAccords()
             initSelectedNote()
-            initLikeCount()
+            setPerfumeLike()
         }
+    }
+
+    private suspend fun fetchPerfumeDetail() {
+        // TODO: get access token
+        _perfumeDetailItem.value =
+            perfumeDetailRepository.fetchPerfumeDetail(
+                token = "",
+                id = perfumeId
+            )
     }
 
     private fun setMainAccords() {
@@ -76,7 +92,8 @@ class PerfumeDetailViewModel @Inject constructor(
         }
     }
 
-    private fun initLikeCount() {
+    private fun setPerfumeLike() {
+        _isLiked.value = _perfumeDetailItem.value?.isLiked
         _likeCount.value = _perfumeDetailItem.value?.likeCount?.toInt()
     }
 
@@ -114,6 +131,18 @@ class PerfumeDetailViewModel @Inject constructor(
             ", ",
             note.map { it.koreanName }
         )
+    }
+
+    fun likePerfume() {
+        viewModelScope.launch(Dispatchers.IO) {
+            // TODO: get access token
+            perfumeDetailRepository.likePerfume(
+                token = "",
+                id = perfumeId
+            )
+            fetchPerfumeDetail()
+            setPerfumeLike()
+        }
     }
 
     enum class PerfumeDetailNote {

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
@@ -28,7 +28,7 @@ class PerfumeDetailViewModel @Inject constructor(
     }
 
     // TODO: Change perfume id value
-    private val perfumeId = 1
+    val perfumeId = 1
 
     private val _perfumeDetailItem = MutableStateFlow<Perfume?>(null)
     val perfumeDetailItem: StateFlow<Perfume?> = _perfumeDetailItem

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeDetailViewModel.kt
@@ -57,12 +57,8 @@ class PerfumeDetailViewModel @Inject constructor(
 
     private fun fetchPerfumeDetail() {
         viewModelScope.launch(Dispatchers.IO) {
-            // TODO: get access token
             _perfumeDetailItem.value =
-                perfumeDetailRepository.fetchPerfumeDetail(
-                    token = "",
-                    id = perfumeId
-                )
+                perfumeDetailRepository.fetchPerfumeDetail(perfumeId)
         }
     }
 
@@ -117,11 +113,7 @@ class PerfumeDetailViewModel @Inject constructor(
 
     fun likePerfume() {
         viewModelScope.launch(Dispatchers.IO) {
-            // TODO: get access token
-            perfumeDetailRepository.likePerfume(
-                token = "",
-                id = perfumeId
-            )
+            perfumeDetailRepository.likePerfume(perfumeId)
             fetchPerfumeDetail()
             setPerfumeLike()
         }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeInformationFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeInformationFragment.kt
@@ -1,6 +1,7 @@
 package com.mashup.lastgarden.ui.main
 
 import android.os.Bundle
+import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.mashup.base.autoCleared
 import com.mashup.lastgarden.R
+import com.mashup.lastgarden.data.vo.Note
 import com.mashup.lastgarden.databinding.FragmentPerfumeInformationBinding
 import com.mashup.lastgarden.ui.BaseViewModelFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -37,12 +39,13 @@ class PerfumeInformationFragment : BaseViewModelFragment() {
         addListenersOnCheckButton()
     }
 
-    override fun onBindViewModelsOnCreate() {
+    override fun onBindViewModelsOnViewCreated() {
         lifecycleScope.launchWhenCreated {
             viewModel.perfumeDetailItem
                 .filterNotNull()
                 .collectLatest {
-                    setMainAccords()
+                    viewModel.initSelectedNote()
+                    setMainAccords(it.accords)
                     setPerfumePyramidVisibility()
                 }
         }
@@ -63,7 +66,7 @@ class PerfumeInformationFragment : BaseViewModelFragment() {
             viewModel.noteContents
                 .filterNotNull()
                 .collectLatest { noteContents ->
-                    if (viewModel.selectedNote.value != null) {
+                    if (viewModel.selectedNoteValue != null) {
                         binding.perfumePyramidInclude.pyramidContentTextView.text = noteContents
                     } else {
                         binding.perfumePyramidInclude.noteContentTextView.text = noteContents
@@ -72,12 +75,13 @@ class PerfumeInformationFragment : BaseViewModelFragment() {
         }
     }
 
-    private fun setMainAccords() {
-        binding.mainAccordsInclude.accordContentTextView.text = viewModel.mainAccords.value
+    private fun setMainAccords(accords: List<Note>?) {
+        binding.mainAccordsInclude.accordContentTextView.text =
+            accords?.let { TextUtils.join(", ", it.map { accord -> accord.koreanName }) }
     }
 
     private fun setPerfumePyramidVisibility() {
-        if (viewModel.selectedNote.value == null) {
+        if (viewModel.selectedNoteValue == null) {
             binding.perfumePyramidInclude.apply {
                 noteContainer.isVisible = true
                 perfumePyramidContainer.isVisible = false

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeInformationFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/PerfumeInformationFragment.kt
@@ -4,14 +4,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.mashup.base.autoCleared
 import com.mashup.lastgarden.R
 import com.mashup.lastgarden.databinding.FragmentPerfumeInformationBinding
 import com.mashup.lastgarden.ui.BaseViewModelFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterNotNull
 
+@AndroidEntryPoint
 class PerfumeInformationFragment : BaseViewModelFragment() {
 
     private var binding by autoCleared<FragmentPerfumeInformationBinding>()
+
+    private val viewModel by viewModels<PerfumeDetailViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -25,41 +34,76 @@ class PerfumeInformationFragment : BaseViewModelFragment() {
 
     override fun onSetupViews(view: View) {
         super.onSetupViews(view)
-        setNoteButtonChecked()
+        addListenersOnCheckButton()
     }
 
-    private fun setNoteButtonChecked() {
-        binding.perfumePyramidInclude.topCheckBox.setOnClickListener {
-            allButtonUnchecked()
-            binding.perfumePyramidInclude.apply {
-                topCheckBox.isChecked = true
-                pyramidImageView.setImageResource(R.drawable.ic_pyramid_top)
-                pyramidContentTextView.text = "시트러스 어코드, 페티그레인, 블랙커런트, 레드프룻, 피치"
-            }
+    override fun onBindViewModelsOnCreate() {
+        lifecycleScope.launchWhenCreated {
+            viewModel.perfumeDetailItem
+                .filterNotNull()
+                .collectLatest {
+                    setMainAccords()
+                    setPerfumePyramidVisibility()
+                }
         }
-        binding.perfumePyramidInclude.middleCheckBox.setOnClickListener {
-            allButtonUnchecked()
-            binding.perfumePyramidInclude.apply {
-                middleCheckBox.isChecked = true
-                pyramidImageView.setImageResource(R.drawable.ic_pyramid_middle)
-                pyramidContentTextView.text = "화이트플라워, 튜베로즈, 재스민, 일랑일랑, 오렌지블로썸, 코코넛"
-            }
+        lifecycleScope.launchWhenCreated {
+            viewModel.selectedNote
+                .filterNotNull()
+                .collectLatest { selectedNote ->
+                    binding.perfumePyramidInclude.topCheckBox.isChecked =
+                        selectedNote == PerfumeDetailViewModel.PerfumeDetailNote.TOP
+                    binding.perfumePyramidInclude.middleCheckBox.isChecked =
+                        selectedNote == PerfumeDetailViewModel.PerfumeDetailNote.MIDDLE
+                    binding.perfumePyramidInclude.baseCheckBox.isChecked =
+                        selectedNote == PerfumeDetailViewModel.PerfumeDetailNote.BASE
+                    viewModel.setNoteContents()
+                }
         }
-        binding.perfumePyramidInclude.baseCheckBox.setOnClickListener {
-            allButtonUnchecked()
+        lifecycleScope.launchWhenCreated {
+            viewModel.noteContents
+                .filterNotNull()
+                .collectLatest { noteContents ->
+                    if (viewModel.selectedNote.value != null) {
+                        binding.perfumePyramidInclude.pyramidContentTextView.text = noteContents
+                    } else {
+                        binding.perfumePyramidInclude.noteContentTextView.text = noteContents
+                    }
+                }
+        }
+    }
+
+    private fun setMainAccords() {
+        binding.mainAccordsInclude.accordContentTextView.text = viewModel.mainAccords.value
+    }
+
+    private fun setPerfumePyramidVisibility() {
+        if (viewModel.selectedNote.value == null) {
             binding.perfumePyramidInclude.apply {
-                baseCheckBox.isChecked = true
-                pyramidImageView.setImageResource(R.drawable.ic_pyramid_base)
-                pyramidContentTextView.text = "샌달우드, 바닐라, 화이트머스크"
+                noteContainer.isVisible = true
+                perfumePyramidContainer.isVisible = false
+            }
+        } else {
+            binding.perfumePyramidInclude.apply {
+                noteContainer.isVisible = false
+                perfumePyramidContainer.isVisible = true
             }
         }
     }
 
-    private fun allButtonUnchecked() {
+    private fun addListenersOnCheckButton() {
         binding.perfumePyramidInclude.apply {
-            topCheckBox.isChecked = false
-            middleCheckBox.isChecked = false
-            baseCheckBox.isChecked = false
+            topCheckBox.setOnClickListener {
+                viewModel.setSelectedNote(PerfumeDetailViewModel.PerfumeDetailNote.TOP)
+                pyramidImageView.setImageResource(R.drawable.ic_pyramid_top)
+            }
+            middleCheckBox.setOnClickListener {
+                viewModel.setSelectedNote(PerfumeDetailViewModel.PerfumeDetailNote.MIDDLE)
+                pyramidImageView.setImageResource(R.drawable.ic_pyramid_middle)
+            }
+            baseCheckBox.setOnClickListener {
+                viewModel.setSelectedNote(PerfumeDetailViewModel.PerfumeDetailNote.BASE)
+                pyramidImageView.setImageResource(R.drawable.ic_pyramid_base)
+            }
         }
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
@@ -70,7 +70,7 @@ class ScentListFragment : BaseViewModelFragment() {
             override fun onStoryItemClick(storyId: Int, storyIndex: Int) {
                 findNavController().navigate(
                     R.id.actionPerfumeDetailFragmentToScentFragment,
-                    bundleOf("storyId" to storyId, "storyIndex" to storyIndex)
+                    bundleOf("storyId" to storyId)
                 )
             }
         })

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
@@ -4,11 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.mashup.base.autoCleared
 import com.mashup.base.image.GlideRequests
+import com.mashup.lastgarden.R
 import com.mashup.lastgarden.databinding.FragmentScentListBinding
 import com.mashup.lastgarden.ui.BaseViewModelFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -43,6 +46,7 @@ class ScentListFragment : BaseViewModelFragment() {
     override fun onSetupViews(view: View) {
         super.onSetupViews(view)
         initRecyclerView()
+        addListener()
     }
 
     override fun onBindViewModelsOnCreate() {
@@ -58,5 +62,17 @@ class ScentListFragment : BaseViewModelFragment() {
         binding.scentListRecyclerView.layoutManager =
             StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL)
         binding.scentListRecyclerView.adapter = perfumeDetailAdapter
+    }
+
+    private fun addListener() {
+        perfumeDetailAdapter.setItemClickListener(object :
+            PerfumeDetailPagingAdapter.OnItemClickListener {
+            override fun onStoryItemClick(storyId: Int, storyIndex: Int) {
+                findNavController().navigate(
+                    R.id.actionPerfumeDetailFragmentToScentFragment,
+                    bundleOf("storyId" to storyId, "storyIndex" to storyIndex)
+                )
+            }
+        })
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
@@ -55,8 +55,8 @@ class ScentListFragment : BaseViewModelFragment() {
     }
 
     private fun initRecyclerView() {
-        binding.recyclerView.layoutManager =
+        binding.scentListRecyclerView.layoutManager =
             StaggeredGridLayoutManager(2, StaggeredGridLayoutManager.VERTICAL)
-        binding.recyclerView.adapter = perfumeDetailAdapter
+        binding.scentListRecyclerView.adapter = perfumeDetailAdapter
     }
 }

--- a/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
+++ b/app/src/main/java/com/mashup/lastgarden/ui/main/ScentListFragment.kt
@@ -13,7 +13,6 @@ import com.mashup.lastgarden.databinding.FragmentScentListBinding
 import com.mashup.lastgarden.ui.BaseViewModelFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filterNotNull
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -23,23 +22,21 @@ class ScentListFragment : BaseViewModelFragment() {
 
     private val viewModel by viewModels<PerfumeDetailViewModel>()
 
-    private lateinit var perfumeDetailAdapter: PerfumeDetailAdapter
+    private lateinit var perfumeDetailAdapter: PerfumeDetailPagingAdapter
 
     @Inject
     lateinit var glideRequests: GlideRequests
 
     override fun onCreated(savedInstanceState: Bundle?) {
         super.onCreated(savedInstanceState)
-        perfumeDetailAdapter = PerfumeDetailAdapter(glideRequests)
+        perfumeDetailAdapter = PerfumeDetailPagingAdapter(glideRequests)
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentScentListBinding.inflate(
-            inflater, container, false
-        )
+        binding = FragmentScentListBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -50,10 +47,9 @@ class ScentListFragment : BaseViewModelFragment() {
 
     override fun onBindViewModelsOnCreate() {
         lifecycleScope.launchWhenCreated {
-            viewModel.perfumeDetailItems
-                .filterNotNull()
+            viewModel.storyItems
                 .collectLatest {
-                    perfumeDetailAdapter.submitList(it)
+                    perfumeDetailAdapter.submitData(it)
                 }
         }
     }

--- a/app/src/main/java/com/mashup/lastgarden/utils/SingleClickListener.kt
+++ b/app/src/main/java/com/mashup/lastgarden/utils/SingleClickListener.kt
@@ -1,0 +1,25 @@
+package com.mashup.lastgarden.utils
+
+import android.view.View
+
+class SingleClickListener(
+    private val intervalTime: Int = 600,
+    private val action: (View) -> Unit
+) : View.OnClickListener {
+    private var lastClickTime: Long = 0
+
+    override fun onClick(view: View) {
+        val systemTime = System.currentTimeMillis()
+        if (systemTime - lastClickTime > intervalTime) {
+            lastClickTime = systemTime
+            action.invoke(view)
+        }
+    }
+}
+
+fun View.setOnSingleClickListener(onClick: (View) -> Unit) {
+    val singleClick = SingleClickListener {
+        onClick(it)
+    }
+    setOnClickListener(singleClick)
+}

--- a/app/src/main/res/layout/fragment_perfume_detail.xml
+++ b/app/src/main/res/layout/fragment_perfume_detail.xml
@@ -1,132 +1,135 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/nestedScrollView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:theme="@style/AppTheme.AppBarOverlay">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@android:color/transparent"
+                app:popupTheme="@style/AppTheme.PopupOverlay">
+
+                <ImageView
+                    android:id="@+id/shareImageView"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="end"
+                    android:layout_marginEnd="20dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:src="@drawable/ic_share"
+                    app:tint="@color/black"
+                    tools:ignore="ContentDescription" />
+
+            </androidx.appcompat.widget.Toolbar>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <com.google.android.material.appbar.AppBarLayout
-                android:id="@+id/appBarLayout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:theme="@style/AppTheme.AppBarOverlay"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-                <androidx.appcompat.widget.Toolbar
-                    android:id="@+id/toolbar"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    android:background="@android:color/transparent"
-                    app:layout_constraintTop_toTopOf="parent">
+                <ImageView
+                    android:id="@+id/photoImageView"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    app:layout_constraintDimensionRatio="1:1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:ignore="ContentDescription" />
 
-                    <ImageView
-                        android:id="@+id/shareImageView"
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_gravity="end"
-                        android:layout_marginEnd="20dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:src="@drawable/ic_share"
-                        app:tint="@color/black" />
+                <TextView
+                    android:id="@+id/titleTextView"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="32dp"
+                    android:textAppearance="@style/TextAppearance.SeeHyangComponents.Headline3"
+                    android:textColor="@color/black"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/photoImageView"
+                    app:layout_constraintTop_toBottomOf="@id/photoImageView"
+                    tools:text="샤넬 가브리엘 에쌍스 오 드 빠르펭" />
 
-                </androidx.appcompat.widget.Toolbar>
+                <TextView
+                    android:id="@+id/titleEngTextView"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="7dp"
+                    android:textAppearance="@style/TextAppearance.SeeHyangComponents.Body1"
+                    android:textColor="#797979"
+                    app:layout_constraintEnd_toEndOf="@id/titleTextView"
+                    app:layout_constraintStart_toStartOf="@id/titleTextView"
+                    app:layout_constraintTop_toBottomOf="@id/titleTextView"
+                    tools:text="Gabrielle Essence Chanel for women" />
 
-            </com.google.android.material.appbar.AppBarLayout>
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tabLayout"
+                    style="@style/Widget.SeeHyangComponents.TabLayout"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/titleEngTextView"
+                    app:tabIconTint="@color/tab_icon_selector"
+                    app:tabIndicatorColor="@color/point"
+                    app:tabPaddingStart="0dp"
+                    app:tabRippleColor="@android:color/transparent" />
 
-            <ImageView
-                android:id="@+id/photoImageView"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintDimensionRatio="1:1"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/appBarLayout" />
+                <View
+                    android:id="@+id/dividerTab"
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:background="@color/colorGrey5"
+                    android:elevation="1dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/viewPager" />
 
-            <TextView
-                android:id="@+id/title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
-                android:layout_marginTop="32dp"
-                android:textAppearance="@style/TextAppearance.SeeHyangComponents.Headline3"
-                android:textColor="@color/black"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/photoImageView"
-                app:layout_constraintTop_toBottomOf="@id/photoImageView"
-                tools:text="샤넬 가브리엘 에쌍스 오 드 빠르펭" />
+                <androidx.viewpager2.widget.ViewPager2
+                    android:id="@+id/viewPager"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tabLayout"
+                    app:layout_constraintVertical_bias="0" />
 
-            <TextView
-                android:id="@+id/titleEngTextView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="7dp"
-                android:textAppearance="@style/TextAppearance.SeeHyangComponents.Body1"
-                android:textColor="#797979"
-                app:layout_constraintEnd_toEndOf="@id/title"
-                app:layout_constraintStart_toStartOf="@id/title"
-                app:layout_constraintTop_toBottomOf="@id/title"
-                tools:text="Gabrielle Essence Chanel for women" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tabLayout"
-                style="@style/Widget.SeeHyangComponents.TabLayout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/titleEngTextView"
-                app:tabIconTint="@color/tab_icon_selector"
-                app:tabIndicatorColor="@color/point"
-                app:tabPaddingStart="0dp"
-                app:tabRippleColor="@android:color/transparent" />
+        </androidx.core.widget.NestedScrollView>
 
-            <View
-                android:id="@+id/dividerTab"
-                android:layout_width="0dp"
-                android:layout_height="1dp"
-                android:background="@color/colorGrey5"
-                android:elevation="1dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/viewPager" />
-
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/viewPager"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tabLayout" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </androidx.core.widget.NestedScrollView>
+    </LinearLayout>
 
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
         android:background="@color/background"
         android:elevation="10dp"
-        app:layout_constraintBottom_toBottomOf="@id/nestedScrollView"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
@@ -145,8 +148,8 @@
                 android:layout_height="24dp"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="5dp"
-                android:src="@drawable/ic_like_empty"
-                app:tint="@color/primaryColor" />
+                app:tint="@color/primaryColor"
+                tools:src="@drawable/ic_like_empty" />
 
             <TextView
                 android:id="@+id/likeCountTextView"
@@ -174,4 +177,4 @@
 
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_perfume_information.xml
+++ b/app/src/main/res/layout/fragment_perfume_information.xml
@@ -35,13 +35,15 @@
             android:layout_width="match_parent"
             android:layout_height="8dp"
             android:layout_marginTop="40dp"
-            android:background="@color/colorGrey6" />
+            android:background="@color/colorGrey6"
+            android:visibility="gone" />
 
         <include
             android:id="@+id/perfumeTypeInclude"
             layout="@layout/include_perfume_type"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_perfume_information.xml
+++ b/app/src/main/res/layout/fragment_perfume_information.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/perfumeInformationContainer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:clipToPadding="false">
+    android:clipToPadding="false"
+    android:paddingBottom="100dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -49,4 +50,4 @@
 
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_perfume_information.xml
+++ b/app/src/main/res/layout/fragment_perfume_information.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/perfumeInformationContainer"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:clipToPadding="false"
-    android:nestedScrollingEnabled="false"
-    android:paddingBottom="190dp">
+    android:layout_height="wrap_content"
+    android:clipToPadding="false">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -36,14 +36,16 @@
             android:layout_height="8dp"
             android:layout_marginTop="40dp"
             android:background="@color/colorGrey6"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <include
             android:id="@+id/perfumeTypeInclude"
             layout="@layout/include_perfume_type"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_scent_list.xml
+++ b/app/src/main/res/layout/fragment_scent_list.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/scentListRecyclerView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="12dp"
-        android:layout_marginTop="4dp"
-        android:clipToPadding="false"
-        android:nestedScrollingEnabled="false"
-        android:overScrollMode="never"
-        android:paddingBottom="150dp" />
-
-</FrameLayout>
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="12dp"
+    android:layout_marginTop="4dp"
+    android:nestedScrollingEnabled="true"
+    android:clipToPadding="false"
+    android:overScrollMode="never"
+    android:paddingBottom="150dp" />

--- a/app/src/main/res/layout/fragment_scent_list.xml
+++ b/app/src/main/res/layout/fragment_scent_list.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:nestedScrollingEnabled="false">
+    android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
@@ -11,6 +10,7 @@
         android:layout_marginHorizontal="12dp"
         android:layout_marginTop="4dp"
         android:clipToPadding="false"
+        android:nestedScrollingEnabled="false"
         android:overScrollMode="never"
         android:paddingBottom="150dp" />
 

--- a/app/src/main/res/layout/fragment_scent_list.xml
+++ b/app/src/main/res/layout/fragment_scent_list.xml
@@ -9,4 +9,4 @@
     android:nestedScrollingEnabled="true"
     android:clipToPadding="false"
     android:overScrollMode="never"
-    android:paddingBottom="150dp" />
+    android:paddingBottom="100dp" />

--- a/base/src/main/java/com/mashup/base/extensions/ImageView.kt
+++ b/base/src/main/java/com/mashup/base/extensions/ImageView.kt
@@ -6,7 +6,7 @@ import com.mashup.base.image.GlideRequests
 
 fun ImageView.loadImage(
     glideRequests: GlideRequests,
-    imageUrl: String,
+    imageUrl: String?,
     @DrawableRes placeholder: Int = 0,
     @DrawableRes errorImage: Int = 0,
 ) {


### PR DESCRIPTION
### Issue id
관련된 이슈를 링크해주세요.



### Why did you make these changes?

* 향수 상세 화면 api 연동


### What did you changed?

* 향수 상세 화면의 향수 정보 api를 연동했습니다. (`getPerfumeDetail`)
* 향수 상세 화면의 씨향지 api를 paging을 통해 연동했습니다. (`getStoryByPerfume`)


### What do you especially want to get reviewed?

* None


### Is there any other comments that every teammate should know?

* 향수 탭 하단의 `Perfume Type`은 아직 서버에서 구현되지 않았다고 전달받아서, 해당 부분을 제외하고는 연동 완료했습니다.
* `Perfume Type` 부분은 보이지 않도록 처리해두었습니다.
* `Perfume.kt` vo에 향수 상세 화면에서 사용되는 `accords` 필드를 추가했습니다. (혹시 수정이 필요하면 말씀해주세요!)
* `PerfumeDetailViewModel.kt`에서 하드코딩해둔 `perfumeId` 변수 값은 이전 화면에서 보내주는 argument에서 받아오는 것으로 화면 연결 후에 수정하겠습니다.
* 향수 좋아요 api도 완성되는대로 올리도록 하겠습니다!


### Checklist

* [x] Gradle task: connectedCheck
* [x] Gradle task: test
* [x] Code formatting
